### PR TITLE
Add GetCommentHeader and Reader.CommentHeader.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -81,6 +81,9 @@ func (r *Reader) Channels() int { return r.dec.Channels() }
 // Bitrate returns a struct containing information about the bitrate.
 func (r *Reader) Bitrate() vorbis.Bitrate { return r.dec.Bitrate }
 
+// CommentHeader returns a struct containing info from the comment header.
+func (r *Reader) CommentHeader() vorbis.CommentHeader { return r.dec.CommentHeader }
+
 // Position returns the current position in samples.
 func (r *Reader) Position() int64 {
 	return r.position - int64(len(r.buffer)/r.Channels()) + int64(r.toSkip/r.Channels())

--- a/util.go
+++ b/util.go
@@ -78,6 +78,23 @@ func GetFormat(in io.Reader) (*Format, error) {
 	}, nil
 }
 
+// GetCommentHeader returns a struct containing info from the comment header.
+func GetCommentHeader(in io.Reader) (vorbis.CommentHeader, error) {
+	var dec vorbis.Decoder
+	r := oggReader{source: in}
+	for i := 0; i < 2; i++ {
+		p, err := r.NextPacket()
+		if err != nil {
+			return vorbis.CommentHeader{}, err
+		}
+		err = dec.ReadHeader(p)
+		if err != nil {
+			return vorbis.CommentHeader{}, err
+		}
+	}
+	return dec.CommentHeader, nil
+}
+
 // GetLength returns the length of the file in samples and the audio format.
 func GetLength(in io.ReadSeeker) (int64, *Format, error) {
 	r := oggReader{source: in, seeker: in}


### PR DESCRIPTION
First, thanks for the useful packages. I've been using the deprecated version of this package, but now I'm switching to the newer one. I like the simplified API, but I miss having access to the comments, so I've added that feature in this PR. Let me know what you think.