### PR TITLE
Fix infinite loop in Restore in case capturePattern couldn't be found

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,17 @@
+package oggvorbis
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFuzzCrashers(t *testing.T) {
+	testData := []string{
+		"\xff\xff\xff\xff\xff\xff\xc9\x03",
+	}
+
+	for _, s := range testData {
+		b := bytes.NewReader([]byte(s))
+		_, _ = NewReader(b)
+	}
+}

--- a/ogg.go
+++ b/ogg.go
@@ -64,7 +64,7 @@ func (r *oggReader) Restore() error {
 		}
 		i := bytes.Index(b[:n], capturePattern[:])
 		if i == -1 {
-			r.buffer = b[n-3:]
+			r.buffer = b[n-3 : n]
 			continue
 		}
 		r.buffer = b[i:n]


### PR DESCRIPTION
I was doing some fuzz-testing on `github.com/jfreymuth/oggvorbis`, and stumbled upon an issue where the Reader would hang in an infinite loop on malformed test data. Basically, when the `capturePattern` couldn't be found in the initial data read, too much of the remaining buffer is appended to the internal buffer that is used in the subsequent read. This leads to `Restore` looping endlessly.

A unit test with the malformed data is also provided in the PR.