### PR TITLE
Fix "capture pattern missing" error for some valid files

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -39,6 +39,7 @@ func (r *Reader) init() error {
 		if err == nil {
 			r.length = length
 		}
+		r.r.buffer = nil
 		r.r.seeker.Seek(0, io.SeekStart)
 	}
 


### PR DESCRIPTION
While trying to play a shuffled folder containing hundreds of songs with a self-built audio player based on this decoder, I noticed on the log output that in rare cases it would just skip to the next song with a "capture pattern missing" error. These were always the same files and e.g. VLC played them without a problem.

After some debugging I noticed that during the "init" function of a NewReader call, the buffer that is checked for the capture pattern wasn't cleared for these files before reading the headers. So I just added a line that always resets it to nil and now all files work perfectly.

However, I have to admit that I am not completely sure if I correctly understood the code as I only looked at it for half an hour and the first thing I tried worked - therefore I am not sure if this has the potential to break something elsewhere!